### PR TITLE
Add OpenGL build to Scoop

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -1,0 +1,33 @@
+{
+    "version": "20250126",
+    "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
+    "homepage": "https://zed.dev/",
+    "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/20250126/zed-windows.zip",
+            "hash": "86ed7ba72a23122f7fd16d12af68b2b8bedb26e3bfe85caafd12ab7ac440ec54"
+        },
+        "opengl": {
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/20250126/zed-windows-opengl.zip",
+            "hash": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+    },
+    "extract_dir": "zed-release",
+    "bin": "zed.exe",
+    "shortcuts": [
+        [
+            "zed.exe",
+            "Zed"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/deevus/zed-windows-builds"
+    },
+    "autoupdate": {
+        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed-windows.zip",
+        "opengl": {
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed-windows-opengl.zip"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #24

Add OpenGL build to Scoop manifest

* Add a new entry for the OpenGL build URL and hash under the `architecture` section in `bucket/zed-nightly.json`
* Update the `autoupdate` section to include the OpenGL build URL in `bucket/zed-nightly.json`

---
