### PR TITLE
feat: inject ZED_UPDATE_EXPLANATION environment variable during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Build release
         working-directory: zed
+        env:
+          ZED_UPDATE_EXPLANATION: "Please use Scoop to update Zed."
         run: cargo build --release
 
       - name: Archive build


### PR DESCRIPTION
- This disables auto-updates within Zed in favor of the package manager (Scoop) updates. (Refer to https://zed.dev/docs/development/linux#notes-for-packaging-zed for more information)