### PR TITLE
Fix stable build showing as failing when no new release

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -36,7 +36,7 @@ jobs:
   trigger_release:
     name: Release
     needs: [check_stable_releases, trigger_build]
-    if: always() && needs.check_stable_releases.result == 'success'
+    if: always() && needs.check_stable_releases.result == 'success' && needs.check_stable_releases.outputs.should_build == 'true'
     uses: ./.github/workflows/release.yml
     with:
       is_prerelease: false


### PR DESCRIPTION
The trigger_release job was running even when should_build was false, causing the workflow to fail when attempting to release non-existent artifacts. Now the release job only runs when a build actually occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)