### PR TITLE
feat: Add /build PR comment trigger

### DIFF
--- a/.github/workflows/pr-comment-build.yml
+++ b/.github/workflows/pr-comment-build.yml
@@ -19,7 +19,8 @@ jobs:
         id: check-command
         run: |
           COMMENT="${{ github.event.comment.body }}"
-          if [[ "$COMMENT" =~ ^/build ]]; then
+          # Match /build exactly (with optional whitespace or end of string)
+          if [[ "$COMMENT" =~ ^/build([[:space:]]|$) ]]; then
             echo "command_found=true" >> $GITHUB_OUTPUT
           else
             echo "command_found=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that allows collaborators to manually trigger builds on PRs by commenting `/build`.

## Changes
- New workflow: `.github/workflows/pr-comment-build.yml`
- Listens for `issue_comment` events on pull requests
- Validates that the commenter has OWNER, MEMBER, or COLLABORATOR permissions
- Triggers the `build.yml` workflow via `workflow_dispatch` with the PR's branch

## How to Use
1. On any open PR, add a comment: `/build`
2. If you have the required permissions, the build workflow will be triggered automatically
3. Check the Actions tab to see the build progress

## Security
- Only users with OWNER, MEMBER, or COLLABORATOR permissions can trigger builds
- Uses `GITHUB_TOKEN` (workflow_dispatch is explicitly allowed as of Sept 2022)
- Silent failure for unauthorized users

## Testing
- ✅ Workflow syntax validated with `act --list`
- ⏳ Live testing will occur after merge to main (issue_comment workflows only run from default branch)