### PR TITLE
fix: use PR workflow for same-repo PRs

### DIFF
--- a/.github/workflows/pr-comment-build.yml
+++ b/.github/workflows/pr-comment-build.yml
@@ -114,13 +114,15 @@ jobs:
               }
 
               // Trigger build workflow
-              // Note: 'ref' parameter specifies which workflow version to run (must exist in base repo)
-              // The PR code to build is passed via inputs.repository and inputs.ref
+              // For fork PRs: Use base branch workflow (PR's workflow doesn't exist in base repo)
+              // For same-repo PRs: Use PR's branch (allows testing workflow changes)
+              const workflowRef = isFork ? pr.data.base.ref : pr.data.head.ref;
+
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'build.yml',
-                ref: pr.data.base.ref,  // Base branch (where workflow exists)
+                ref: workflowRef,
                 inputs: {
                   repository: headRepo,       // Fork or base repo
                   ref: pr.data.head.sha       // SHA to build
@@ -139,7 +141,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `✅ Build triggered for PR #${context.issue.number}\n\n- Repository: \`${headRepo}\`\n- Branch: \`${pr.data.head.ref}\`\n- Commit: \`${pr.data.head.sha.substring(0, 7)}\`\n\nCheck the [Actions tab](/${context.repo.owner}/${context.repo.repo}/actions) for progress.`
+                body: `✅ Build triggered for PR #${context.issue.number}\n\n- Repository: \`${headRepo}\`\n- Branch: \`${pr.data.head.ref}\`\n- Commit: \`${pr.data.head.sha.substring(0, 7)}\`\n- Workflow: \`${workflowRef}\` ${isFork ? '(base branch - fork PR)' : '(PR branch - testing workflow changes)'}\n\nCheck the [Actions tab](/${context.repo.owner}/${context.repo.repo}/actions) for progress.`
               });
 
               console.log(`Build triggered for PR #${context.issue.number}`);


### PR DESCRIPTION
## Summary
Fixes  command to test PR's workflow changes for same-repository PRs.

## Problem
The  command always used the base branch workflow, preventing PRs from testing their own workflow modifications. Since this repository's purpose is maintaining build workflows, PRs should test their changes.

## Solution
- **Same-repo PRs**: Use `pr.data.head.ref` (tests PR's workflow changes) ✅
- **Fork PRs**: Use `pr.data.base.ref` (workflow file doesn't exist in base repo)

## Technical Details
`createWorkflowDispatch` requires the workflow file to exist in the base repository at the specified ref. Fork PR refs don't exist in the base repo, so we must fall back to the base branch for those.

## Changes
- Dynamically select workflow ref based on fork status
- Updated success message to show which workflow version is running
- Maintains fork PR compatibility

This allows testing workflow changes in PRs while handling the fork constraint correctly.