### PR TITLE
fix: correct /build command to always build zed-industries/zed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          override: true
           target: wasm32-wasip1
 
       - name: Rust Cache

--- a/.github/workflows/pr-comment-build.yml
+++ b/.github/workflows/pr-comment-build.yml
@@ -19,9 +19,13 @@ jobs:
         id: check-command
         run: |
           COMMENT="${{ github.event.comment.body }}"
-          # Match /build exactly (with optional whitespace or end of string)
-          if [[ "$COMMENT" =~ ^/build([[:space:]]|$) ]]; then
+          # Match /build with optional ref argument
+          # Examples: /build, /build main, /build v0.165.2, /build preview
+          if [[ "$COMMENT" =~ ^/build([[:space:]]+([^[:space:]]+))?([[:space:]]|$) ]]; then
             echo "command_found=true" >> $GITHUB_OUTPUT
+            # Extract ref argument (defaults to 'main' if not provided)
+            BUILD_REF="${BASH_REMATCH[2]:-main}"
+            echo "build_ref=$BUILD_REF" >> $GITHUB_OUTPUT
           else
             echo "command_found=false" >> $GITHUB_OUTPUT
           fi
@@ -118,14 +122,17 @@ jobs:
               // For same-repo PRs: Use PR's branch (allows testing workflow changes)
               const workflowRef = isFork ? pr.data.base.ref : pr.data.head.ref;
 
+              // Get the build ref from the command (e.g., /build main, /build v0.165.2)
+              const buildRef = '${{ steps.check-command.outputs.build_ref }}';
+
               await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'build.yml',
                 ref: workflowRef,
                 inputs: {
-                  repository: headRepo,       // Fork or base repo
-                  ref: pr.data.head.sha       // SHA to build
+                  repository: 'zed-industries/zed',  // Always build official Zed
+                  ref: buildRef                       // Branch/tag from /build command
                 }
               });
 
@@ -141,12 +148,12 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `✅ Build triggered for PR #${context.issue.number}\n\n- Repository: \`${headRepo}\`\n- Branch: \`${pr.data.head.ref}\`\n- Commit: \`${pr.data.head.sha.substring(0, 7)}\`\n- Workflow: \`${workflowRef}\` ${isFork ? '(base branch - fork PR)' : '(PR branch - testing workflow changes)'}\n\nCheck the [Actions tab](/${context.repo.owner}/${context.repo.repo}/actions) for progress.`
+                body: `✅ Build triggered for PR #${context.issue.number}\n\n- Building: \`zed-industries/zed@${buildRef}\`\n- Workflow ref: \`${workflowRef}\` ${isFork ? '(base branch - fork PR)' : '(PR branch - testing workflow changes)'}\n\nCheck the [Actions tab](/${context.repo.owner}/${context.repo.repo}/actions) for progress.`
               });
 
               console.log(`Build triggered for PR #${context.issue.number}`);
-              console.log(`Repository: ${headRepo}`);
-              console.log(`Ref: ${pr.data.head.sha}`);
+              console.log(`Building: zed-industries/zed@${buildRef}`);
+              console.log(`Workflow ref: ${workflowRef}`);
             } catch (error) {
               // Error handling with user feedback
               await github.rest.reactions.createForIssueComment({


### PR DESCRIPTION
## Summary

Fixes the `/build` command workflow to properly build the official Zed repository instead of incorrectly attempting to build the PR's repository (zed-windows-builds).

## Problem

When using `/build` on PR #102, the workflow failed with:
```
error: could not find `Cargo.toml` in `D:\a\zed-windows-builds\zed-windows-builds\zed`
```

The issue was that `pr-comment-build.yml` was passing `deevus/zed-windows-builds` as the repository input to `build.yml`, but `build.yml` expects the Zed source repository (`zed-industries/zed`).

## Changes

### 1. Enhanced `/build` Command Parsing
- Now supports optional ref argument: `/build [ref]`
- Examples:
  - `/build` → builds `zed-industries/zed@main` (default)
  - `/build main` → builds `zed-industries/zed@main`
  - `/build v0.165.2` → builds `zed-industries/zed@v0.165.2`
  - `/build preview` → builds `zed-industries/zed@preview`

### 2. Fixed Workflow Dispatch Inputs
- Changed `repository` input to always be `zed-industries/zed`
- Changed `ref` input to use the parsed ref from the `/build` command
- Updated success comment to clearly show what's being built

### 3. Rust Toolchain Fix
- Removed invalid `override: true` input from `dtolnay/rust-toolchain` action in `build.yml`
- This was causing warnings (but not failures) in workflow runs

## Testing

To test this PR:
1. Comment `/build` on this PR to trigger a build of `zed-industries/zed@main`
2. Comment `/build preview` to trigger a build of `zed-industries/zed@preview`

## Related

- Fixes the failure in PR #102 run https://github.com/deevus/zed-windows-builds/actions/runs/18964962365

🤖 Generated with [Claude Code](https://claude.com/claude-code)