### PR TITLE
fix: use ISO date format for nightly release tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Building release from $REPO#$SHA: $MSG"
           echo "build_ref=$REF" >> $GITHUB_OUTPUT
           echo "build_repo=$REPO" >> $GITHUB_OUTPUT
-          echo "release_tag=$(date +'%m-%d-%Y')" >> $GITHUB_OUTPUT
+          echo "release_tag=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           echo "release_body=Built from $REPO commit [$SHA]($URL): $MSG" >> $GITHUB_OUTPUT
 
   trigger_build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zed/
 .claude/settings.local.json
+docs/plans/


### PR DESCRIPTION
## Summary

- Changes nightly release tag format from `MM-DD-YYYY` to `YYYY-MM-DD` (ISO format)
- Fixes GitHub API sorting issue where releases with identical `created_at` timestamps sort incorrectly by tag name

## Problem

All releases since Nov 12, 2025 share the same `created_at` timestamp (the commit date they point to). The API sub-sorts alphabetically by tag name, causing `12-31-2025` to appear before `01-09-2026`. This breaks Scoop's version detection.

## Solution

ISO format naturally sorts chronologically when sorted alphabetically:
- `2026-01-10` > `2026-01-09` > `2025-12-31` ✓

## Follow-up

After this merges, a separate PR will be needed for the Scoop manifests:
- `ScoopInstaller/Versions/bucket/zed-nightly.json`
- `ScoopInstaller/Versions/bucket/zed-opengl-nightly.json`

Fixes #114

🤖 Generated with [Claude Code](https://claude.ai/code)